### PR TITLE
Fix incorrect number of arguments error in filename_helpers

### DIFF
--- a/lib/rspec-prof/filename_helpers.rb
+++ b/lib/rspec-prof/filename_helpers.rb
@@ -18,7 +18,7 @@ class RSpecProf
 
     def path_for metadata
       if metadata[:example_group]
-        File.join(path_for(metadata[:example_group], metadata[:description]))
+        File.join(path_for(metadata[:example_group]), metadata[:description])
       else
         metadata[:description]
       end


### PR DESCRIPTION
This fixes a problem we were having with an ArgumentError which looked like this:

```
ArgumentError:
       wrong number of arguments (2 for 1)
     # /Users/dan/.rvm/gems/ruby-2.0.0-p247@nbuild/gems/rspec-prof-0.0.5/lib/rspec-prof/filename_helpers.rb:19:in `path_for'
     # /Users/dan/.rvm/gems/ruby-2.0.0-p247@nbuild/gems/rspec-prof-0.0.5/lib/rspec-prof/filename_helpers.rb:21:in `path_for'
     # /Users/dan/.rvm/gems/ruby-2.0.0-p247@nbuild/gems/rspec-prof-0.0.5/lib/rspec-prof/filename_helpers.rb:28:in `filename_for'
     # /Users/dan/.rvm/gems/ruby-2.0.0-p247@nbuild/gems/rspec-prof-0.0.5/lib/rspec-prof.rb:72:in `block (2 levels) in <top (required)>'
```
