### PR TITLE
Limit profiling report to the top 99% percent

### DIFF
--- a/lib/rspec-prof.rb
+++ b/lib/rspec-prof.rb
@@ -45,7 +45,7 @@ class RSpecProf
     FileUtils.mkdir_p File.dirname(filename)
     File.open(filename, "w") do |f|
       printer = RSpecProf.printer_class.new(result)
-      printer.print f
+      printer.print(f, :min_percent => 1)
     end
   end
 end


### PR DESCRIPTION
We rarely if ever care about any code that consumes less than 1% of
CPU/Wall time, allocations, etc.

For tests that take less than a few seconds, it's not a huge deal but
for anything more than that, it takes forever to run and creates an
enormous html file with mostly useless information:

**Without profiling**
`bundle exec rake test  1.13s user 0.18s system 98% cpu 1.319 total`

**With profiling, before this commit**
`RSPEC_PROFILE=all bundle exec rake test  6.95s user 0.38s system 99% cpu 7.350 total`

Produces an 11 MB html file.

**With profiling, after this commit**
`RSPEC_PROFILE=all bundle exec rake test  1.92s user 0.20s system 99% cpu 2.131 total`

Produces an 75 KB html file.