### PR TITLE
Update path for "all" output to listen to config.

### DIFF
--- a/lib/rspec-prof.rb
+++ b/lib/rspec-prof.rb
@@ -63,7 +63,7 @@ RSpec.configure do |config|
 
   config.after(:suite) do
     if ENV['RSPEC_PROFILE'] == 'all'
-      @profiler.save_to  "profiles/all.html"
+      @profiler.save_to "#{RSpecProf.output_dir}/all.#{RSpecProf.file_extension}"
     end
   end
 


### PR DESCRIPTION
Why:

* The "all" profile will wrote it's output to profiles/all.html no
  matter what the output_dir and file_extension configs were set to.

This change addresses the need by:

* Update path for the "all" profile to use the output_dir and
  file_extension configs.