### PR TITLE
Prevent warnings for @profile being uninitialized

### DIFF
--- a/lib/rspec-prof.rb
+++ b/lib/rspec-prof.rb
@@ -18,6 +18,10 @@ class RSpecProf
       profiler.save_to filename
     end
   end
+  
+  def initialize
+    @profiling = nil
+  end
 
   def start
     return if @profiling


### PR DESCRIPTION
This prevents the following warnings:

> /Users/mikaelhenriksson/.rvm/gems/ruby-2.3.1/gems/rspec-prof-0.0.7/lib/rspec-prof.rb:23: warning: instance variable @profiling not initialized

You should really run the test suite with warnings turned on in the future.
